### PR TITLE
Adding method to get invoices filtered by OData query

### DIFF
--- a/src/Strike.Client/Invoices/StrikeClient.Invoices.cs
+++ b/src/Strike.Client/Invoices/StrikeClient.Invoices.cs
@@ -40,6 +40,13 @@ public sealed partial class StrikeClient
 				.ParseResponseAsync<InvoicesCollection>();
 
 		/// <summary>
+		/// Get all invoices filtered by OData query
+		/// </summary>
+		public Task<InvoicesCollection> GetInvoicesFilter(string filter, int top = 100, int skip = 0) =>
+			Client.Get($"/v1/invoices?$top={top}&$skip={skip}&$filter={filter}")
+				.ParseResponseAsync<InvoicesCollection>();
+
+		/// <summary>
 		/// Issue a new quote for the target invoice
 		/// </summary>
 		public Task<InvoiceQuote> IssueQuote(Guid invoiceId, InvoiceQuoteReq? request = null) =>

--- a/test_integration/Strike.Client.IntegrationTests/InvoicesTests.cs
+++ b/test_integration/Strike.Client.IntegrationTests/InvoicesTests.cs
@@ -33,6 +33,10 @@ public class InvoicesTests : TestsBase
 		var allInvoices = await client.Invoices.GetInvoices();
 		AssertStatus(allInvoices);
 		Assert.NotEmpty(allInvoices.Items);
+		
+		var invoicesFiltered = await client.Invoices.GetInvoicesFilter($"invoiceId in ('{invoice.InvoiceId}')");
+		AssertStatus(invoicesFiltered);
+		Assert.NotEmpty(invoicesFiltered.Items);
 	}
 
 	[SkippableFact]

--- a/test_integration/Strike.Client.IntegrationTests/InvoicesTests.cs
+++ b/test_integration/Strike.Client.IntegrationTests/InvoicesTests.cs
@@ -33,7 +33,7 @@ public class InvoicesTests : TestsBase
 		var allInvoices = await client.Invoices.GetInvoices();
 		AssertStatus(allInvoices);
 		Assert.NotEmpty(allInvoices.Items);
-		
+
 		var invoicesFiltered = await client.Invoices.GetInvoicesFilter($"invoiceId in ('{invoice.InvoiceId}')");
 		AssertStatus(invoicesFiltered);
 		Assert.NotEmpty(invoicesFiltered.Items);


### PR DESCRIPTION
Allowing lib user to query the status of multiple invoices with one HTTP call.