### PR TITLE
Updating 'System.Text.Json' for net8.0 build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageVersion Include="System.Net.Http.Json" Version="8.0.0" />
-		<PackageVersion Include="System.Text.Json" Version="8.0.4" />
+		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/src/Strike.Client/Strike.Client.csproj
+++ b/src/Strike.Client/Strike.Client.csproj
@@ -5,6 +5,7 @@
 		<RootNamespace>Strike.Client</RootNamespace>
 
 		<TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 


### PR DESCRIPTION
Resolves: #11 

The other builds (net6.0 and netcoreapp3.1) also need to be updated. I've also added TargetFramework attribute since otherwise csproj can't be directly referenced in the solution for debugging. 